### PR TITLE
Updates underlying publish plugin to latest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
 	compile(gradleApi())
-	compile(group: 'com.gradle.publish', name: 'plugin-publish-plugin', version: '0.9.3')
+	compile(group: 'com.gradle.publish', name: 'plugin-publish-plugin', version: '1.0.0')
 }
 
 // un-set the java source directories since this is a pure kotlin project


### PR DESCRIPTION
Apparently there is a security vulnerability and an upgrade is required.

> This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability.
> Please update to the latest version of the com.gradle.plugin-publish plugin found here:
>    https://plugins.gradle.org/plugin/com.gradle.plugin-publish
> You can read more about this vulnerability here:
>    https://blog.gradle.org/plugin-portal-update